### PR TITLE
feat(0.2): adds psr-4 autoloading in functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     },
     "autoload": {
         "psr-4": {
-            "Pest\\PluginLivewire\\": "src/"
+            "Pest\\Livewire\\": "src/"
         },
         "files": ["src/Plugin.php"]
     },
     "autoload-dev": {
         "psr-4": {
-            "Pest\\PluginLivewire\\Tests\\": "tests/"
+            "Tests\\": "tests/"
         }
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "psr-4": {
             "Pest\\Livewire\\": "src/"
         },
-        "files": ["src/Plugin.php"]
+        "files": ["src/Livewire.php", "src/Plugin.php"]
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.3",
         "livewire/livewire": "^1.1",
-        "pestphp/pest": "^0.1.5"
+        "pestphp/pest": "^0.2"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -8,6 +8,6 @@ parameters:
     paths:
         - src
 
-    checkMissingIterableValueType: true
+    checkMissingIterableValueType: false
     checkGenericClassInNonGenericObjectType: false
     reportUnmatchedIgnoredErrors: true

--- a/src/InteractsWithLivewire.php
+++ b/src/InteractsWithLivewire.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Pest\PluginLivewire;
+namespace Pest\Livewire;
 
 use Livewire\Livewire;
 use Livewire\Testing\TestableLivewire;

--- a/src/Livewire.php
+++ b/src/Livewire.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Livewire;
+
+use Livewire\Testing\TestableLivewire;
+
+function livewire(string $name, array $params = []): TestableLivewire
+{
+    return test()->livewire(...func_get_args());
+}

--- a/src/Livewire.php
+++ b/src/Livewire.php
@@ -6,7 +6,10 @@ namespace Pest\Livewire;
 
 use Livewire\Testing\TestableLivewire;
 
-function livewire(string $name, array $params = []): TestableLivewire
+/**
+ * @return TestableLivewire
+ */
+function livewire(string $name, array $params = [])
 {
     return test()->livewire(...func_get_args());
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -2,6 +2,6 @@
 
 declare(strict_types=1);
 
-use Pest\PluginLivewire\InteractsWithLivewire;
+use Pest\Livewire\InteractsWithLivewire;
 
 Pest\Plugin::uses(InteractsWithLivewire::class);

--- a/tests/Plugin.php
+++ b/tests/Plugin.php
@@ -1,5 +1,6 @@
 <?php
 
+use function Pest\Livewire\livewire;
 use Tests\TestCase;
 use Tests\TestComponent;
 
@@ -17,3 +18,5 @@ it('can test a livewire component')
 it('can test a livewire component with parameters')
     ->livewire(TestComponent::class, ['title' => 'bar'])
     ->assertSet('title', 'bar');
+
+livewire(TestComponent::class)->assertSet('title', null);

--- a/tests/Plugin.php
+++ b/tests/Plugin.php
@@ -1,7 +1,7 @@
 <?php
 
-use Pest\PluginLivewire\Tests\TestCase;
-use Pest\PluginLivewire\Tests\TestComponent;
+use Tests\TestCase;
+use Tests\TestComponent;
 
 uses(TestCase::class);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pest\PluginLivewire\Tests;
+namespace Tests;
 
 use Livewire\LivewireServiceProvider;
 use Orchestra\Testbench\TestCase as BaseTestCase;

--- a/tests/TestComponent.php
+++ b/tests/TestComponent.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Pest\PluginLivewire\Tests;
+namespace Tests;
 
 use Livewire\Component;
 


### PR DESCRIPTION
This pull request prepares the Livewire Plugin for Pest 0.2

Also added a higher order proxy method to allow the new syntax of:
```php
livewire(TestComponent::class)->assertSet('title', 'foobar'); 
```

Related to https://github.com/pestphp/pest-plugin-laravel/pull/7