### PR TITLE
Update to use simplified structure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
         "psr-4": {
             "Pest\\Livewire\\": "src/"
         },
-        "files": ["src/Livewire.php", "src/Plugin.php"]
+        "files": [
+          "src/Autoload.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
             "Pest\\Livewire\\": "src/"
         },
         "files": [
-          "src/Autoload.php"
+            "src/Autoload.php"
         ]
     },
     "autoload-dev": {

--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Pest\Livewire;
 
 use Livewire\Testing\TestableLivewire;
+use Pest\Plugin;
+
+Plugin::uses(InteractsWithLivewire::class);
 
 /**
  * @return TestableLivewire

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,7 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-use Pest\Livewire\InteractsWithLivewire;
-
-Pest\Plugin::uses(InteractsWithLivewire::class);


### PR DESCRIPTION
This just moves it into a single file to be autoloaded by Composer, which also now matches the updated plugin template. 👍

Not really sure, but this might actually resolve https://github.com/pestphp/pest/issues/96, as the `Plugin::uses()` call will always be called before the `livewire()` function is created.