### PR TITLE
Livewire 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.3",
-        "livewire/livewire": "^1.2",
+        "livewire/livewire": "^2.0",
         "pestphp/pest": "^0.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.3",
-        "livewire/livewire": "^2.0",
+        "livewire/livewire": "^1.2|^2.0",
         "pestphp/pest": "^0.3"
     },
     "autoload": {


### PR DESCRIPTION
This PR requires Livewire 2 which was recently released.

Alternatively we could support both Livewire 1 and 2, but I guess that is not preferred.