### PR TITLE
ci: add PHP 8

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        php: ['7.3', '7.4']
+        php: ['7.3', '7.4', '8.0']
         dependency-version: [prefer-lowest, prefer-stable]
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,16 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         php: ['7.3', '7.4', '8.0']
         dependency-version: [prefer-lowest, prefer-stable]
+        exclude:
+          - os: ubuntu-latest
+            php: 8.0
+            dependency-version: prefer-lowest
+          - os: macos-latest
+            php: 8.0
+            dependency-version: prefer-lowest
+          - os: windows-latest
+            php: 8.0
+            dependency-version: prefer-lowest
 
     name: PHP ${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         }
     },
     "require-dev": {
-        "orchestra/testbench": "^5.2",
+        "orchestra/testbench": "^6.4",
         "pestphp/pest-dev-tools": "dev-master"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
Looks like there isn't a release of Livewire with PHP 8 support yet. Waiting for a release that contains https://github.com/livewire/livewire/commit/ac8321905c32dcea5e5fde89fef93d59109570ab 👍🏻