### PR TITLE
Add support for Livewire::withQueryParams

### DIFF
--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -16,3 +16,11 @@ function livewire(string $name, array $params = [])
 {
     return test()->livewire(...func_get_args());
 }
+
+/**
+ * @return TestableLivewire
+ */
+function livewireWithQuery(string $name, array $params = [], array $query = [])
+{
+    return test()->livewireWithQuery(...func_get_args());
+}

--- a/src/InteractsWithLivewire.php
+++ b/src/InteractsWithLivewire.php
@@ -14,4 +14,13 @@ trait InteractsWithLivewire
     {
         return Livewire::test($name, $params);
     }
+
+    /**
+     * @param array<string, mixed> $params
+     * @param array<string, mixed> $query
+     */
+    public function livewireWithQuery(string $name, array $params = [], array $query = []): TestableLivewire
+    {
+        return Livewire::withQueryParams($query)->test($name, $params);
+    }
 }

--- a/tests/Plugin.php
+++ b/tests/Plugin.php
@@ -1,6 +1,8 @@
 <?php
 
+use Livewire\Livewire;
 use function Pest\Livewire\livewire;
+use function Pest\Livewire\livewireWithQuery;
 use Tests\TestCase;
 use Tests\TestComponent;
 
@@ -20,3 +22,10 @@ it('can test a livewire component with parameters')
     ->assertSet('title', 'bar');
 
 livewire(TestComponent::class)->assertSet('title', null);
+
+it('can test a livewire component with querystring', function () {
+    livewire(TestComponent::class)->assertSet('search', null);
+    livewire(TestComponent::class, ['search' => 'xxx'])->assertSet('search', 'xxx');
+    livewireWithQuery(TestComponent::class, [], [])->assertSet('search', null);
+    livewireWithQuery(TestComponent::class, [], ['search' => 'monkey'])->assertSet('search', 'monkey');
+});

--- a/tests/TestComponent.php
+++ b/tests/TestComponent.php
@@ -7,6 +7,9 @@ use Livewire\Component;
 class TestComponent extends Component
 {
     public $title;
+    public $search;
+
+    protected $queryString = ['search'];
 
     public function mount(string $title = ''): void
     {


### PR DESCRIPTION
### Added
function *livewireWithQuery* to support [Livewire::withQueryParams](https://laravel-livewire.com/docs/2.x/testing)

### Why?

Although querystring parameter can be set via the standard "livewire" helper method it makes sense to implement this method in my opinion. Simply to see more clearly that a querystring parameter is used.

### Example
```php
livewireWithQuery(TestComponent::class, [], ['search' => 'monkey'])->assertSet('search', 'monkey');
```