### PR TITLE
Add `livewire()` method to the expectations

### DIFF
--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pest\Livewire;
 
 use Livewire\Testing\TestableLivewire;
+use Pest\Expectation;
 use Pest\Plugin;
 
 Plugin::uses(InteractsWithLivewire::class);
@@ -16,3 +17,10 @@ function livewire(string $name, array $params = [])
 {
     return test()->livewire(...func_get_args());
 }
+
+expect()->extend('livewire', function (array $params = []): Expectation {
+    // @phpstan-ignore-next-line
+    $this->value = livewire($this->value, $params);
+    // @phpstan-ignore-next-line
+    return $this;
+});

--- a/tests/Plugin.php
+++ b/tests/Plugin.php
@@ -20,3 +20,27 @@ it('can test a livewire component with parameters')
     ->assertSet('title', 'bar');
 
 livewire(TestComponent::class)->assertSet('title', null);
+
+it('can create a new expectation as a livewire component')
+    ->expect(TestComponent::class)->livewire()
+    ->lastRenderedDom
+    ->toBeString()
+    ->set('title', 'foo')
+    ->assertSet('title', 'foo')
+    ->get('status')
+    ->toBeTrue()
+    ->assertSee('foo')
+    ->set('status', false)
+    ->assertSet('status', false);
+
+it('can create a new expectation as livewire a component with parameters')
+    ->expect(TestComponent::class)->livewire(['title' => 'bar'])
+    ->toBeInstanceOf('Livewire\Testing\TestableLivewire')
+    ->lastRenderedDom
+    ->toBeString()
+    ->assertSet('title', 'bar')
+    ->set('title', 'foo')
+    ->assertSet('title', 'foo')
+    ->toBeInstanceOf('Livewire\Testing\TestableLivewire')
+    ->get('title')
+    ->toBeString();

--- a/tests/TestComponent.php
+++ b/tests/TestComponent.php
@@ -7,6 +7,7 @@ use Livewire\Component;
 class TestComponent extends Component
 {
     public $title;
+    public $status = true;
 
     public function mount(string $title = ''): void
     {


### PR DESCRIPTION
```php
it('test')
    ->expect(TestComponent::class)->livewire()
    ->toBeInstanceOf('Livewire\Testing\TestableLivewire')
    ->lastRenderedDom
    ->toBeString()
    ->set('title', 'foo')
    ->assertSet('title', 'foo')
    ->get('status')
    ->toBeTrue()
    ->assertSee('foo')
    ->set('status', false)
    ->assertSet('status', false)
    ->get('rows')
    ->toBeInstanceOf('\Illuminate\Pagination\LengthAwarePaginator');
```

```php
it('test')
    ->expect(TestComponent::class)->livewire(['title' => 'bar'])
    ->assertSet('title', 'bar')
    ->get('status')
    ->toBeTrue();
```