### PR TITLE
Fixed PHPStan error "Call to method <method> on an unknown class Livewire\Features\SupportTesting\Testable"

### DIFF
--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -10,22 +10,8 @@ use Pest\Plugin;
 
 Plugin::uses(InteractsWithLivewire::class);
 
-if (class_exists(Testable::class)) {
-    /**
-     * @return Testable // @phpstan-ignore-next-line
-     */
-    function livewire(string $name, array $params = [])
-    {
-        // @phpstan-ignore-next-line
-        return test()->livewire(...func_get_args());
-    }
-} else {
-    /**
-     * @return TestableLivewire
-     */
-    function livewire(string $name, array $params = [])
-    {
-        // @phpstan-ignore-next-line
-        return test()->livewire(...func_get_args());
-    }
+function livewire(string $name, array $params = [])
+{
+    // @phpstan-ignore-next-line
+    return test()->livewire(...func_get_args());
 }


### PR DESCRIPTION
As discussed on [Twitte.. uh.. X](https://twitter.com/enunomaduro/status/1683825233273167873), here's the PR without annotations.

Tested locally with Livewire v2 - this works for me