### PR TITLE
[2.x] Add ability to perform `toMatchSnapshot` on Livewire components

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,13 @@
             "pestphp/pest-plugin": true
         }
     },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Pest\\Livewire\\PestServiceProvider"
+            ]
+        }
+    },
     "scripts": {
         "lint": "pint",
         "test:lint": "pint --test",

--- a/src/PestServiceProvider.php
+++ b/src/PestServiceProvider.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pest\Livewire;
+
+use Illuminate\Support\ServiceProvider;
+use Illuminate\Testing\TestResponse;
+use Laravel\Dusk\Console\DuskCommand;
+use Livewire\Features\SupportTesting\Testable;
+use Pest\Laravel\Commands\PestDatasetCommand;
+use Pest\Laravel\Commands\PestDuskCommand;
+use Pest\Laravel\Commands\PestTestCommand;
+use Pest\Plugins\Snapshot;
+
+final class PestServiceProvider extends ServiceProvider
+{
+    /**
+     * Register Artisan Commands.
+     */
+    public function register(): void
+    {
+        // Livewire v3.x
+        if(class_exists(Testable::class)) {
+            Snapshot::intercept(Testable::class, function (Testable $component): string {
+                return $component->html(stripInitialData: true);
+            });
+        }
+
+        Snapshot::macro('livewire.wire-key', function (string $value) {
+            return preg_replace('/wire:id="[0-9a-zA-Z]*"/', 'wire:id="..."', $value);
+        });
+    }
+}


### PR DESCRIPTION
This PR adds support for snapshot testing on Livewire components.

This PR depends on https://github.com/pestphp/pest/pull/954