### PR TITLE
Add support for Livewire 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "livewire/livewire": "^3.6.4",
+        "livewire/livewire": "^4.0.1",
         "pestphp/pest": "^4.0.0"
     },
     "autoload": {

--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -11,7 +11,7 @@ Plugin::uses(InteractsWithLivewire::class);
 
 /**
  * @param  array<array-key, mixed>  $params
- * @return Testable
+ * @return Testable<\Livewire\Component>
  */
 function livewire(string $name, array $params = [])
 {


### PR DESCRIPTION
- Update Livewire dependency from ^3.6.4 to ^4.0.1
- Fix generic type annotation for `livewire()` helper function return type